### PR TITLE
fix: can't start dev server when using npm

### DIFF
--- a/packages/cli/src/dev.ts
+++ b/packages/cli/src/dev.ts
@@ -101,10 +101,9 @@ function getVitroConfig(): VitroConfig {
 export default command
 
 async function start({ port, verbose, packageManager }) {
-    const NPM_NEXT_BIN = path.join(NEXT_APP_PATH, `node_modules/.bin/next`)
     const command =
         packageManager === 'npm'
-            ? `${NPM_NEXT_BIN} dev -p ${port}`
+            ? `npm run dev -- -p ${port}`
             : `yarn next dev -p ${port}`
     return await runCommand({
         command,


### PR DESCRIPTION
This PR fixes an issue when starting vitro command using npm instead of yarn.

Output before this fix:
```
starting the server
/bin/sh: .vitro/node_modules/.bin/next: No such file or directory

could not start the dev server, Error: could not start vitro
```